### PR TITLE
Adds a required_providers block with a minimum version for the aws provider

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.0
+current_version = 3.0.1
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ Terraform module to create a keystore within S3/SSM
 | Name | Version |
 |------|---------|
 | terraform | >= 0.13 |
+| aws | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
+| aws | >= 3.0 |
 
 ## Inputs
 

--- a/tests/ssm/main.tf
+++ b/tests/ssm/main.tf
@@ -49,9 +49,11 @@ module "keystore_namespace" {
 }
 
 output "keystore" {
-  value = module.keystore
+  value     = module.keystore
+  sensitive = true
 }
 
 output "keystore_namespace" {
-  value = module.keystore_namespace
+  value     = module.keystore_namespace
+  sensitive = true
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,10 @@
 terraform {
   required_version = ">= 0.13"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.0"
+    }
+  }
 }


### PR DESCRIPTION
This helps resolve warnings in tf 0.15 of the form:

```
Module module.<KEYSTORE> does not declare a provider named aws.
If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers block within the module.
```